### PR TITLE
Add CLI utilities for Vision API script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,17 @@
 # plattenkiste
 This repository contains scripts designed to process images and interact with the OpenAI Vision API. The main functionalities include loading and resizing images, extracting text using OCR, and sending queries to the Vision API for image analysis.
+
+## Usage
+
+```bash
+python visionAPI.py path/to/image.jpg --config config.toml --send-image --output result.json
+```
+
+Provide an `OPENAI_API_KEY` environment variable or store the key in a TOML file:
+
+```toml
+[api]
+key = "your key"
+```
+
+The `--send-image` flag includes the processed image in the request. Using `--output` writes the structured response to the specified JSON file.

--- a/config.toml.example
+++ b/config.toml.example
@@ -1,2 +1,4 @@
 [api]
+# API key for accessing the OpenAI service.
 key = "your key"
+

--- a/visionAPI.py
+++ b/visionAPI.py
@@ -1,8 +1,11 @@
+import argparse
 import base64
 import io
 import json
+import os
 import re
 from pathlib import Path
+from typing import Any, Dict, Optional
 
 import httpx
 import pytesseract
@@ -11,39 +14,46 @@ from PIL import Image
 
 
 class ConfigLoader:
-    def __init__(self, config_file):
+    """Load configuration values from a TOML file."""
+
+    def __init__(self, config_file: Path):
         self.config_file = config_file
         self.config = self.load_config()
 
-    def load_config(self):
-        with open(self.config_file, "r") as f:
+    def load_config(self) -> Dict[str, Any]:
+        with open(self.config_file, "r", encoding="utf-8") as f:
             config = toml.load(f)
         return config
 
 
 class ImageProcessor:
-    def __init__(self, config_file, image_path):
+    """Process images and query the OpenAI Vision API."""
+
+    def __init__(self, config_file: Path, image_path: Path):
         self.config_loader = ConfigLoader(config_file)
         self.config = self.config_loader.config
         self.image_path = image_path
-        self.api_key = self.config["api"]["key"]
-        self.text = None
-        self.image_base64 = None
-        self.response = None
-        self.original_image = None
-        self.parsed_response = None
+        self.api_key = self.config["api"].get("key") or os.getenv("OPENAI_API_KEY")
+        self.text: Optional[str] = None
+        self.image_base64: Optional[str] = None
+        self.response: Optional[str] = None
+        self.original_image: Optional[Image.Image] = None
+        self.parsed_response: Optional[Dict[str, Any]] = None
 
-    def process(self, send_image):
+    def process(self, send_image: bool) -> None:
+        """Run preprocessing and send question to the Vision API."""
         self.preprocess_image()
         self.ask_question_to_vision_api(send_image)
 
-    def show_image(self):
+    def show_image(self) -> None:
+        """Display the original image."""
         if self.original_image:
             self.original_image.show()
         else:
             print("process first")
 
-    def preprocess_image(self):
+    def preprocess_image(self) -> None:
+        """Run OCR and prepare the image for API submission."""
         image = Image.open(self.image_path)
         self.original_image = image
         try:
@@ -68,13 +78,14 @@ class ImageProcessor:
         self.image_base64 = base64.b64encode(image_bytes).decode("utf-8")
 
     @staticmethod
-    def clean_ocr_text(text):
-        # Entferne leere Zeilen
+    def clean_ocr_text(text: str) -> str:
+        """Remove empty lines from OCR text."""
         lines = text.split("\n")
         cleaned_lines = [line for line in lines if line.strip()]
         return "\n".join(cleaned_lines)
 
-    def ask_question_to_vision_api(self, send_image: bool = False):
+    def ask_question_to_vision_api(self, send_image: bool = False) -> None:
+        """Query the Vision API and parse the JSON response."""
         question = f"""
         please fill the following json strings with the informations from the image and the ocr data without further informations and comments without mardown notation.
             "interpret": null,
@@ -89,65 +100,79 @@ class ImageProcessor:
             "Authorization": f"Bearer {self.api_key}",
             "Content-Type": "application/json",
         }
-        if send_image:
-            data = {
-                "model": "gpt-4o",
-                "messages": [
-                    {
-                        "role": "user",
-                        "content": [
-                            {"type": "text", "text": question},
-                            {
-                                "type": "image_url",
-                                "image_url": {
-                                    "url": f"data:image/jpeg;base64,{self.image_base64}"
-                                },
-                            },
-                        ],
-                    }
-                ],
-                "max_tokens": 300,
-            }
-        else:
-            data = {
-                "model": "gpt-4o",
-                "messages": [
-                    {
-                        "role": "user",
-                        "content": [
-                            {"type": "text", "text": question},
-                        ],
-                    }
-                ],
-                "max_tokens": 300,
-            }
-        with httpx.Client() as client:
-            response = client.post(url, headers=headers, json=data, timeout=10)
-        response = response.json()
-        response = response["choices"][0]["message"]["content"]
-        print(response)
-        self.parsed_response = self.parse_response(response)
+        content = [{"type": "text", "text": question}]
+        if send_image and self.image_base64:
+            content.append(
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:image/jpeg;base64,{self.image_base64}"},
+                }
+            )
+        data = {
+            "model": "gpt-4o",
+            "messages": [{"role": "user", "content": content}],
+            "max_tokens": 300,
+        }
+        try:
+            with httpx.Client() as client:
+                response = client.post(url, headers=headers, json=data, timeout=10)
+            response.raise_for_status()
+            json_response = response.json()
+            message_content = json_response["choices"][0]["message"]["content"]
+            print(message_content)
+            self.parsed_response = self.parse_response(message_content)
+        except httpx.HTTPError as exc:
+            print(f"HTTP error: {exc}")
 
     @staticmethod
-    def parse_response(response):
+    def parse_response(response: str) -> Optional[Dict[str, Any]]:
+        """Extract a JSON string from the API response and return it as a dictionary."""
         json_match = re.search(r"{.*}", response, re.DOTALL)
         if json_match:
             json_string = json_match.group(0)
             try:
-                # Parse the JSON string into a dictionary
-                parsed_dict = json.loads(json_string)
-                # Print the parsed dictionary
-                return parsed_dict
+                return json.loads(json_string)
             except json.JSONDecodeError as e:
                 print(f"Error parsing JSON: {e}")
         else:
             print("No JSON string found.")
+        return None
+
+    def save_response(self, output_path: Path) -> None:
+        """Save the parsed response as a JSON file."""
+        if self.parsed_response is None:
+            print("Nothing to save.")
+            return
+        with open(output_path, "w", encoding="utf-8") as f:
+            json.dump(self.parsed_response, f, ensure_ascii=False, indent=2)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Process an image and query the OpenAI Vision API."
+    )
+    parser.add_argument("image", type=Path, help="Path to the image file.")
+    parser.add_argument(
+        "--config",
+        type=Path,
+        default=Path("config.toml"),
+        help="Path to the TOML configuration file.",
+    )
+    parser.add_argument(
+        "--send-image",
+        action="store_true",
+        help="Include the image in the request to the API.",
+    )
+    parser.add_argument(
+        "--output", type=Path, help="Optional path to save the JSON response."
+    )
+    args = parser.parse_args()
+
+    processor = ImageProcessor(args.config, args.image)
+    processor.process(send_image=args.send_image)
+    if args.output:
+        processor.save_response(args.output)
 
 
 if __name__ == "__main__":
-    image_processor = ImageProcessor(
-        "config.toml", Path(r"C:\Users\simon.schulte\Downloads\Bild2.jpg")
-    )
-    image_processor.process(send_image=False)
-    print(image_processor.parsed_response)
-    image_processor.show_image()
+    main()


### PR DESCRIPTION
## Summary
- add command-line interface for processing images, optional image upload, and saving responses
- support API key via config file or OPENAI_API_KEY environment variable
- update docs and example config for new CLI

## Testing
- `python -m py_compile visionAPI.py`
- `python visionAPI.py --help` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `python -m pip install httpx toml pillow pytesseract` *(fails: Could not find a version that satisfies the requirement httpx; Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_688b4c6c50c483288dbf2bdb14ca9a5f