### PR TITLE
Add Discogs price lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,14 +4,19 @@ This repository contains scripts designed to process images and interact with th
 ## Usage
 
 ```bash
-python visionAPI.py path/to/image.jpg --config config.toml --send-image --output result.json
+python visionAPI.py path/to/image.jpg --config config.toml --send-image --lookup-price --output result.json
 ```
 
-Provide an `OPENAI_API_KEY` environment variable or store the key in a TOML file:
+Provide an `OPENAI_API_KEY` environment variable or store the key in a TOML file. The configuration can also include a Discogs token for price lookups:
 
 ```toml
 [api]
 key = "your key"
+
+[discogs]
+token = "your token"
 ```
 
-The `--send-image` flag includes the processed image in the request. Using `--output` writes the structured response to the specified JSON file.
+Create a Discogs personal access token by registering an application at [discogs.com/settings/developers](https://www.discogs.com/settings/developers).
+
+The `--send-image` flag includes the processed image in the request. `--lookup-price` queries Discogs for a price suggestion, and using `--output` writes the structured response to the specified JSON file.

--- a/config.toml.example
+++ b/config.toml.example
@@ -2,3 +2,7 @@
 # API key for accessing the OpenAI service.
 key = "your key"
 
+[discogs]
+# Personal access token for the Discogs API.
+token = "your token"
+


### PR DESCRIPTION
## Summary
- add Discogs token configuration and document setup
- implement Discogs price fetch and optional CLI flag
- persist fetched price in output

## Testing
- `python -m py_compile visionAPI.py`
- `python visionAPI.py --help` *(fails: ModuleNotFoundError: No module named 'httpx')*
- `pip install httpx` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6895cf0f66948328acf34195324c7532