### PR TITLE
Initialize Discogs token and pass it to price lookup

### DIFF
--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -8,6 +8,9 @@ import pytest
 for name in ["httpx", "pytesseract", "toml"]:
     sys.modules[name] = types.ModuleType(name)
 
+# Provide a minimal implementation for toml.load so configuration loading works.
+sys.modules["toml"].load = lambda f: {"api": {"key": "dummy"}}
+
 pil_module = types.ModuleType("PIL")
 pil_image_module = types.ModuleType("Image")
 pil_module.Image = pil_image_module
@@ -37,4 +40,33 @@ def test_parse_response_with_valid_json():
 def test_parse_response_without_json_returns_none():
     response = "No JSON here"
     assert ImageProcessor.parse_response(response) is None
+
+
+def test_process_lookup_price_uses_configured_token(monkeypatch, tmp_path):
+    """process() should pass the Discogs token without raising errors."""
+    # Create temporary files required by ImageProcessor
+    config_file = tmp_path / "config.toml"
+    config_file.write_text("[api]\nkey='dummy'\n")
+    image_file = tmp_path / "image.jpg"
+    image_file.write_text("fake")
+
+    processor = ImageProcessor(config_file, image_file)
+    processor.parsed_response = {"album_title": "Dummy"}
+
+    # Avoid heavy processing or network calls
+    monkeypatch.setattr(ImageProcessor, "preprocess_image", lambda self: None)
+    monkeypatch.setattr(ImageProcessor, "ask_question_to_vision_api", lambda self, send_image: None)
+
+    called = {"token": None}
+
+    def fake_fetch(info, token):
+        called["token"] = token
+        return 1.23
+
+    monkeypatch.setattr("visionAPI.fetch_discogs_price", fake_fetch)
+
+    processor.process(send_image=False, lookup_price=True)
+
+    assert called["token"] is None
+    assert processor.parsed_response["discogs_price_eur"] == 1.23
 

--- a/visionAPI.py
+++ b/visionAPI.py
@@ -45,6 +45,8 @@ class ImageProcessor:
         self.config = self.config_loader.config
         self.image_path = image_path
         self.api_key = self.config["api"].get("key") or os.getenv("OPENAI_API_KEY")
+        # Store the Discogs token so it can be reused later.
+        self.discogs_token = self.config_loader.discogs_token
 
         self.text: Optional[str] = None
         self.image_base64: Optional[str] = None
@@ -57,7 +59,10 @@ class ImageProcessor:
         self.preprocess_image()
         self.ask_question_to_vision_api(send_image)
         if lookup_price and self.parsed_response:
-            price = fetch_discogs_price(self.parsed_response, self.discogs_token)
+            # Use the configured Discogs token when looking up prices.
+            price = fetch_discogs_price(
+                self.parsed_response, self.discogs_token
+            )
             if price is not None:
                 self.parsed_response["discogs_price_eur"] = price
 


### PR DESCRIPTION
## Summary
- store Discogs token from config during `ImageProcessor` initialization
- pass the configured token to `fetch_discogs_price` when looking up prices
- add regression test verifying price lookup works without attribute errors

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6895d37872608328964389516f6d47c4