### PR TITLE
Handle configuration overrides for vision processor

### DIFF
--- a/visionAPI.py
+++ b/visionAPI.py
@@ -45,18 +45,17 @@ class ImageProcessor:
         self.config_loader = ConfigLoader(config_file)
         self.config = self.config_loader.config
         self.image_path = image_path
-        self.api_key = self.config["api"].get("key") or os.getenv("OPENAI_API_KEY")
-        self.model = model or self.config["api"].get("model")
+        api_config = self.config.get("api", {})
+        self.api_key = api_config.get("key") or os.getenv("OPENAI_API_KEY")
+        self.model = model if model is not None else api_config.get("model")
         self.prompt_template = (
-            prompt_template or self.config["api"].get("prompt_template", "")
+            prompt_template
+            if prompt_template is not None
+            else api_config.get("prompt_template", "")
         )
-        self.discogs_token = self.config_loader.discogs_token
-
-        self.model = model or self.config.get("api", {}).get("model")
-        self.prompt_template = (
-            prompt_template or self.config.get("api", {}).get("prompt_template")
+        self.discogs_token = (
+            discogs_token if discogs_token is not None else self.config_loader.discogs_token
         )
-        self.discogs_token = discogs_token or self.config_loader.discogs_token
 
         self.text: Optional[str] = None
         self.image_base64: Optional[str] = None


### PR DESCRIPTION
## Summary
- honor provided model and prompt template with config fallback
- carry Discogs token through processing for price lookups

## Testing
- `pytest -q`
- smoke test exercising process and Discogs lookup


------
https://chatgpt.com/codex/tasks/task_e_6895d7707c488328a59295283ee65f58